### PR TITLE
bump geo version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "Rust bindings for proj"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",
@@ -11,5 +11,5 @@ keywords = ["proj", "projection", "osgeo", "geo"]
 license = "Apache-2.0"
 
 [dependencies]
-geo ="0.0.4"
+geo ="0.0.5"
 libc = "0.1.7"


### PR DESCRIPTION
We need to bump the version so the latest versions of rust-gdal, rust-geo, and rust-proj all play nice together.
