### PR TITLE
Bump dependency version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
 rust:
-  - 1.0.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ license = "Apache-2.0"
 [dependencies]
 geo ="^0.4"
 libc = "0.1.7"
-num-traits = "0.1.39"
+num-traits = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "Rust bindings for proj"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "Rust bindings for proj"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",
@@ -11,5 +11,6 @@ keywords = ["proj", "projection", "osgeo", "geo"]
 license = "Apache-2.0"
 
 [dependencies]
-geo ="0.0.4"
+geo ="^0.4"
 libc = "0.1.7"
+num-traits = "0.1.39"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate num_traits;
 extern crate geo;
 extern crate libc;
 

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -1,6 +1,7 @@
 use libc::{c_int, c_char, c_long, c_double};
 use std::ffi::CString;
 use geo::{Point, Coordinate};
+use num_traits::Float;
 use std::ffi::CStr;
 use std::str;
 
@@ -15,19 +16,18 @@ pub struct Proj {
 
 
 #[link(name="proj")]
-extern {
+extern "C" {
     fn pj_init_plus(definition: *const c_char) -> *const ();
     fn pj_free(pj: *const ());
     fn pj_get_def(pj: *const ()) -> *const c_char;
-    fn pj_transform(
-        srcdefn: *const (),
-        dstdefn: *const (),
-        point_count: c_long,
-        point_offset: c_int,
-        x: *mut c_double,
-        y: *mut c_double,
-        z: *mut c_double
-    ) -> c_int;
+    fn pj_transform(srcdefn: *const (),
+                    dstdefn: *const (),
+                    point_count: c_long,
+                    point_offset: c_int,
+                    x: *mut c_double,
+                    y: *mut c_double,
+                    z: *mut c_double)
+                    -> c_int;
     fn pj_strerrno(code: c_int) -> *const c_char;
 }
 
@@ -43,9 +43,9 @@ impl Proj {
         let c_definition = CString::new(definition.as_bytes()).unwrap();
         let c_proj = unsafe { pj_init_plus(c_definition.as_ptr()) };
         return match c_proj.is_null() {
-            true  => None,
-            false => Some(Proj{c_proj: c_proj}),
-        };
+                   true => None,
+                   false => Some(Proj { c_proj: c_proj }),
+               };
     }
 
     pub fn def(&self) -> String {
@@ -53,33 +53,38 @@ impl Proj {
         return _string(rv);
     }
 
-    pub fn project(&self, target: &Proj, point: Point) -> Point {
-        let mut c_x: c_double = point.0.x;
-        let mut c_y: c_double = point.0.y;
+    pub fn project<T>(&self, target: &Proj, point: Point<T>) -> Point<T>
+        where T: Float
+    {
+        let mut c_x: c_double = point.0.x.to_f64().unwrap();
+        let mut c_y: c_double = point.0.y.to_f64().unwrap();
         let mut c_z: c_double = 0.;
         unsafe {
-            let rv = pj_transform(
-                self.c_proj,
-                target.c_proj,
-                1,
-                1,
-                &mut c_x,
-                &mut c_y,
-                &mut c_z
-            );
+            let rv = pj_transform(self.c_proj,
+                                  target.c_proj,
+                                  1,
+                                  1,
+                                  &mut c_x,
+                                  &mut c_y,
+                                  &mut c_z);
             if rv != 0 {
                 println!("{}", error_message(rv));
             }
             assert!(rv == 0);
         }
-        return Point(Coordinate{x: c_x, y: c_y});
+        return Point(Coordinate {
+                         x: T::from(c_x).unwrap(),
+                         y: T::from(c_y).unwrap(),
+                     });
     }
 }
 
 
 impl Drop for Proj {
     fn drop(&mut self) {
-        unsafe { pj_free(self.c_proj); }
+        unsafe {
+            pj_free(self.c_proj);
+        }
     }
 }
 
@@ -94,9 +99,8 @@ mod test {
     fn test_new_projection() {
         let wgs84 = "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs";
         let proj = Proj::new(wgs84).unwrap();
-        assert_eq!(
-            proj.def(),
-            " +proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +towgs84=0,0,0");
+        assert_eq!(proj.def(),
+                   " +proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +towgs84=0,0,0");
     }
 
 
@@ -113,11 +117,19 @@ mod test {
         let wgs84 = Proj::new(wgs84_name).unwrap();
         let stereo70 = Proj::new("+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +units=m +no_defs").unwrap();
 
-        let rv = stereo70.project(&wgs84, Point(Coordinate {x: 500000., y: 500000.}));
+        let rv = stereo70.project(&wgs84,
+                                  Point(Coordinate {
+                                            x: 500000.,
+                                            y: 500000.,
+                                        }));
         assert_almost_eq(rv.0.x, 0.436332);
         assert_almost_eq(rv.0.y, 0.802851);
 
-        let rv = wgs84.project(&stereo70, Point(Coordinate {x: 0.436332, y: 0.802851}));
+        let rv = wgs84.project(&stereo70,
+                               Point(Coordinate {
+                                         x: 0.436332,
+                                         y: 0.802851,
+                                     }));
         assert_almost_eq(rv.0.x, 500000.);
         assert_almost_eq(rv.0.y, 500000.);
     }

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -16,18 +16,19 @@ pub struct Proj {
 
 
 #[link(name="proj")]
-extern "C" {
+extern {
     fn pj_init_plus(definition: *const c_char) -> *const ();
     fn pj_free(pj: *const ());
     fn pj_get_def(pj: *const ()) -> *const c_char;
-    fn pj_transform(srcdefn: *const (),
-                    dstdefn: *const (),
-                    point_count: c_long,
-                    point_offset: c_int,
-                    x: *mut c_double,
-                    y: *mut c_double,
-                    z: *mut c_double)
-                    -> c_int;
+    fn pj_transform(
+        srcdefn: *const (),
+        dstdefn: *const (),
+        point_count: c_long,
+        point_offset: c_int,
+        x: *mut c_double,
+        y: *mut c_double,
+        z: *mut c_double
+    ) -> c_int;
     fn pj_strerrno(code: c_int) -> *const c_char;
 }
 
@@ -43,9 +44,9 @@ impl Proj {
         let c_definition = CString::new(definition.as_bytes()).unwrap();
         let c_proj = unsafe { pj_init_plus(c_definition.as_ptr()) };
         return match c_proj.is_null() {
-                   true => None,
-                   false => Some(Proj { c_proj: c_proj }),
-               };
+               true => None,
+               false => Some(Proj{c_proj: c_proj}),
+           };
     }
 
     pub fn def(&self) -> String {
@@ -60,13 +61,15 @@ impl Proj {
         let mut c_y: c_double = point.0.y.to_f64().unwrap();
         let mut c_z: c_double = 0.;
         unsafe {
-            let rv = pj_transform(self.c_proj,
-                                  target.c_proj,
-                                  1,
-                                  1,
-                                  &mut c_x,
-                                  &mut c_y,
-                                  &mut c_z);
+            let rv = pj_transform(
+                self.c_proj,
+                target.c_proj,
+                1,
+                1,
+                &mut c_x,
+                &mut c_y,
+                &mut c_z
+            );
             if rv != 0 {
                 println!("{}", error_message(rv));
             }
@@ -82,9 +85,7 @@ impl Proj {
 
 impl Drop for Proj {
     fn drop(&mut self) {
-        unsafe {
-            pj_free(self.c_proj);
-        }
+        unsafe { pj_free(self.c_proj); }
     }
 }
 
@@ -99,8 +100,9 @@ mod test {
     fn test_new_projection() {
         let wgs84 = "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs";
         let proj = Proj::new(wgs84).unwrap();
-        assert_eq!(proj.def(),
-                   " +proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +towgs84=0,0,0");
+        assert_eq!(
+            proj.def(),
+            " +proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +towgs84=0,0,0");
     }
 
 
@@ -117,19 +119,11 @@ mod test {
         let wgs84 = Proj::new(wgs84_name).unwrap();
         let stereo70 = Proj::new("+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +units=m +no_defs").unwrap();
 
-        let rv = stereo70.project(&wgs84,
-                                  Point(Coordinate {
-                                            x: 500000.,
-                                            y: 500000.,
-                                        }));
+        let rv = stereo70.project(&wgs84, Point(Coordinate { x: 500000., y: 500000. }));
         assert_almost_eq(rv.0.x, 0.436332);
         assert_almost_eq(rv.0.y, 0.802851);
 
-        let rv = wgs84.project(&stereo70,
-                               Point(Coordinate {
-                                         x: 0.436332,
-                                         y: 0.802851,
-                                     }));
+        let rv = wgs84.project(&stereo70, Point(Coordinate { x: 0.436332, y: 0.802851 }));
         assert_almost_eq(rv.0.x, 500000.);
         assert_almost_eq(rv.0.y, 500000.);
     }


### PR DESCRIPTION
This PR (also related to #3) updates the version number of the `geo` crate and adds the `num_traits` crate as a dependency, so this should allow for better integration with the `geo` crate.

By the way, I don't know what is the best pattern to follow in this kind of cases (so I don't particularly advocate this solution), but is it really necessary to use the type `geo::Point` as input / output for the `Proj::project` method?
This involves adding the "geo" crate to a project only to use this function (while it might take as input / output something like `(f64, f64)` or `Vec<f64>` ; that's what I did on [another branch](https://github.com/mthh/rust-proj/blob/withoutgeo/src/proj.rs#L56) for a project not using the `geo` crate for now).