### PR TITLE
Move to proj-sys and proj.4 v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ rust:
   - nightly
 before_install:
   - sudo apt-get update
-  - sudo apt-get install libproj-dev
+  - wget https://github.com/OSGeo/proj.4/releases/download/5.0.0/proj-5.0.0.tar.gz
+  - tar -xzvf proj-5.0.0.tar.gz
+  - pushd proj-5.0.0 && ./configure --prefix=/usr && make && sudo make install && popd

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,14 @@
+# Changes
+
+## 0.4.0
+
+* [Switch to `proj-sys` crate, and PROJ.4 v5.0.0 API](https://github.com/georust/rust-proj/pull/6)
+    * Split operations into `project` and `convert`
+    * `project` and `convert` return `Result`
+
+
+## 0.3.0
+
+* [Use `c_void` instead of unit](https://github.com/georust/rust-proj/pull/5)
+    * Add example to README
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,11 @@ authors = [
 ]
 repository = "https://github.com/georust/rust-proj"
 keywords = ["proj", "projection", "osgeo", "geo"]
-license = "Apache-2.0"
+license = "MIT/Apache-2.0"
 
 [dependencies]
 proj-sys = "0.2.0"
 geo ="^0.7"
 libc = "0.2.39"
 num-traits = "^0.1"
+failure = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["proj", "projection", "osgeo", "geo"]
 license = "Apache-2.0"
 
 [dependencies]
-proj-sys = "0.1.0"
+proj-sys = "0.2.0"
 geo ="^0.7"
 libc = "0.2.39"
 num-traits = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "Rust bindings for proj.4"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["proj", "projection", "osgeo", "geo"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-proj-sys = "0.2.0"
+proj-sys = "0.3.0"
 geo ="^0.7"
 libc = "0.2.39"
 num-traits = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "Rust bindings for proj.4"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["proj", "projection", "osgeo", "geo"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-proj-sys = "0.3.0"
+proj-sys = "0.4.0"
 geo ="^0.7"
 libc = "0.2.39"
 num-traits = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "Rust bindings for proj.4"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",
@@ -11,6 +11,7 @@ keywords = ["proj", "projection", "osgeo", "geo"]
 license = "Apache-2.0"
 
 [dependencies]
+proj-sys = "0.1.0"
 geo ="^0.7"
 libc = "0.2.39"
 num-traits = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "Rust bindings for proj.4"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proj"
 description = "Rust bindings for proj.4"
-version = "0.6.1"
+version = "0.4.0"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",
@@ -11,7 +11,7 @@ keywords = ["proj", "projection", "osgeo", "geo"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-proj-sys = "0.4.0"
+proj-sys = "0.6.1"
 geo ="^0.7"
 libc = "0.2.39"
 num-traits = "^0.1"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2017 The GeoRust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,16 @@ use proj::Proj;
 extern crate geo;
 use geo::types::Point;
 
-let nad_ft_to_m = Proj::new("+proj=pipeline +step +inv +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000 +y_0=500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs").unwrap();
+let nad_ft_to_m = Proj::new("
+    +proj=pipeline
+    +step +inv +proj=lcc +lat_1=33.88333333333333
+    +lat_2=32.78333333333333 +lat_0=32.16666666666666
+    +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80
+    +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs
+    +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666
+    +lon_0=-116.25 +x_0=2000000 +y_0=500000
+    +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
+").unwrap();
 # The Presidio, approximately
 let result = nad_ft_to_m.convert(Point::new(4760096.421921, 3744293.729449)).unwrap();
 assert_eq!(result.x(), 1450880.29);

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Rust bindings for [proj.4](https://github.com/OSGeo/proj.4), v5.0.x
 
 # Example
-## Reproject from [Stereo70](https://epsg.io/3844) to [WGS84](https://epsg.io/4326)
+## Inverse Projection from [Stereo70](https://epsg.io/3844) to Geodetic
 ```rust
 extern crate proj;
 use proj::Proj;

--- a/README.md
+++ b/README.md
@@ -2,7 +2,28 @@
 
 Rust bindings for [proj.4](https://github.com/OSGeo/proj.4), v5.0.x
 
-# Example
+# Examples
+Note that as of v5.0.0, proj.5 uses the [`pipeline`](http://proj4.org/operations/pipeline.html) operator, which allows an arbitrary number of steps in a conversion. The first example below works as follows:
+
+- define the operation as a `pipeline` operation
+- define `step` 1 as an `inv`erse transform, yielding geodetic coordinates
+- define `step` 2 as a forward transform to projected coordinates, yielding metres.
+
+## Convert from [NAD 83 US Survey Feet](https://epsg.io/2230) to [NAD 83 Meters](https://epsg.io/26946)
+```rust
+extern crate proj;
+use proj::Proj;
+
+extern crate geo;
+use geo::types::Point;
+
+let nad_ft_to_m = Proj::new("+proj=pipeline +step +inv +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000 +y_0=500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs").unwrap();
+# The Presidio, approximately
+let result = nad_ft_to_m.convert(Point::new(4760096.421921, 3744293.729449)).unwrap();
+assert_eq!(result.x(), 1450880.29);
+assert_eq!(result.y(), 1141263.01);
+```
+
 ## Inverse Projection from [Stereo70](https://epsg.io/3844) to Geodetic
 ```rust
 extern crate proj;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-proj
 
-Rust bindings for [PROJ.4 v4.9.x](https://github.com/OSGeo/proj.4)
+Rust bindings for [proj.4](https://github.com/OSGeo/proj.4), v5.0
 
 # Example
 ## Reproject from [Stereo70](https://epsg.io/3844) to [WGS84](https://epsg.io/4326)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # rust-proj
 
-Rust bindings for [proj.4](https://github.com/OSGeo/proj.4), v5.0.x
+Rust bindings for [PROJ.4](https://github.com/OSGeo/proj.4), v5.0.x
 
 # Examples
-Note that as of v5.0.0, proj.5 uses the [`pipeline`](http://proj4.org/operations/pipeline.html) operator, which allows an arbitrary number of steps in a conversion. The first example below works as follows:
+Note that as of v5.0.0, PROJ.4 uses the [`pipeline`](http://proj4.org/operations/pipeline.html) operator, which allows an arbitrary number of steps in a conversion. The first example below works as follows:
 
 - define the operation as a `pipeline` operation
 - define `step` 1 as an `inv`erse transform, yielding geodetic coordinates
@@ -46,7 +46,7 @@ let stereo70 = Proj::new(
     "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs"
     ).unwrap();
 let rp = stereo70.project(Point::new(500119.70352012233, 500027.77896348457), true).unwrap();
-assert_eq(rp, Point::new(0.436332, 0.802851));
+assert_eq!(rp, Point::new(0.436332, 0.802851));
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-proj
 
-Rust bindings for [proj.4](https://github.com/OSGeo/proj.4), v5.0
+Rust bindings for [proj.4](https://github.com/OSGeo/proj.4), v5.0.x
 
 # Example
 ## Reproject from [Stereo70](https://epsg.io/3844) to [WGS84](https://epsg.io/4326)
@@ -15,8 +15,17 @@ use geo::types::Point;
 let wgs84_name = "+proj=longlat +datum=WGS84 +no_defs";
 let wgs84 = Proj::new(wgs84_name).unwrap();
 let stereo70 = Proj::new(
-    "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +units=m +no_defs"
+    "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs"
     ).unwrap();
 let rp = stereo70.project(&wgs84, Point::new(500000., 500000.));
 assert_eq(rp, Point::new(0.436332, 0.802851));
 ```
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ let nad_ft_to_m = Proj::new("
     +lon_0=-116.25 +x_0=2000000 +y_0=500000
     +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
 ").unwrap();
-# The Presidio, approximately
+// The Presidio, approximately
 let result = nad_ft_to_m.convert(Point::new(4760096.421921, 3744293.729449)).unwrap();
 assert_eq!(result.x(), 1450880.29);
 assert_eq!(result.y(), 1141263.01);
@@ -41,13 +41,11 @@ use proj::Proj;
 extern crate geo;
 use geo::types::Point;
 
-// reproject coordinates from Stereo70 with custom params into geodetic coordinates (in radians)
-let wgs84_name = "+proj=longlat +datum=WGS84 +no_defs";
-let wgs84 = Proj::new(wgs84_name).unwrap();
+// Carry out an inverse projection from Pulkovo 1942(58) / Stereo70 (EPSG 3844) into geodetic lon and lat coordinates (in radians)
 let stereo70 = Proj::new(
     "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs"
     ).unwrap();
-let rp = stereo70.project(&wgs84, Point::new(500000., 500000.));
+let rp = stereo70.project(Point::new(500119.70352012233, 500027.77896348457), true).unwrap();
 assert_eq(rp, Point::new(0.436332, 0.802851));
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,11 @@
 //! coordinate systems. The proj.4 [documentation](http://proj4.org/operations/index.html)
 //! explains the distinction between these operations.
 
-extern crate num_traits;
+#[macro_use]
+extern crate failure;
 extern crate geo;
 extern crate libc;
+extern crate num_traits;
 extern crate proj_sys;
 
 mod proj;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
-//! Rust bindings for [PROJ.4](https://github.com/OSGeo/proj.4) v4.9.x
+//! `proj` provides bindings to the [proj.4](http://proj4.org), v5.0.x API
+//!
+//! Two coordinate operations are currently provided: projection (and inverse projection)
+//! and conversion. Projection is intended for transforming between geodetic and projected coordinates,
+//! and vice versa (inverse projection), while conversion is intended for transforming between projected
+//! coordinate systems. The proj.4 [documentation](http://proj4.org/operations/index.html)
+//! explains the distinction between these operations.
 
 extern crate num_traits;
 extern crate geo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate num_traits;
 extern crate geo;
 extern crate libc;
+extern crate proj_sys;
 
 mod proj;
 

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -91,6 +91,11 @@ mod test {
     use geo::Point;
     use super::Proj;
 
+    fn assert_almost_eq(a: f64, b: f64) {
+        let f: f64 = a / b;
+        assert!(f < 1.00001);
+        assert!(f > 0.99999);
+    }
     #[test]
     fn test_new_projection() {
         let wgs84 = "+proj=longlat +datum=WGS84 +no_defs";
@@ -100,25 +105,9 @@ mod test {
             "proj=longlat datum=WGS84 no_defs ellps=WGS84 towgs84=0,0,0"
         );
     }
-
-    fn assert_almost_eq(a: f64, b: f64) {
-        let f: f64 = a / b;
-        assert!(f < 1.00001);
-        assert!(f > 0.99999);
-    }
-
     #[test]
-    fn test_transform_stereo() {
-        let stereo70 = Proj::new(
-            "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +units=m +no_defs"
-            ).unwrap();
-        // stereo70 -> WGS84
-        let t = stereo70.project(Point::new(500000., 500000.), true);
-        assert_almost_eq(t.x(), 0.436332);
-        assert_almost_eq(t.y(), 0.802851);
-    }
-    #[test]
-    fn test_transform_wgs84() {
+    // Carry out a projection from geodetic coordinates
+    fn test_project() {
         let stereo70 = Proj::new(
             "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +units=m +no_defs"
             ).unwrap();
@@ -126,5 +115,16 @@ mod test {
         let t = stereo70.project(Point::new(0.436332, 0.802851), false);
         assert_almost_eq(t.x(), 500000.);
         assert_almost_eq(t.y(), 500000.);
+    }
+    #[test]
+    // Carry out an inverse projection to geodetic coordinates
+    fn test_inverse_project() {
+        let stereo70 = Proj::new(
+            "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +units=m +no_defs"
+            ).unwrap();
+        // stereo70 -> WGS84
+        let t = stereo70.project(Point::new(500000., 500000.), true);
+        assert_almost_eq(t.x(), 0.436332);
+        assert_almost_eq(t.y(), 0.802851);
     }
 }

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -152,7 +152,6 @@ impl Proj {
             new_y = trans.xy.y;
             err = proj_errno(self.c_proj);
         }
-        // TODO: replace this with a proj error when we know how to detect them
         if err == 0 {
             Ok(Point::new(T::from(new_x).unwrap(), T::from(new_y).unwrap()))
         } else {

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -234,7 +234,6 @@ mod test {
         ).unwrap();
         // OSGB36 (EPSG 27700) -> Geodetic
         let t = osgb36.project(Point::new(548295.39, 182498.46), true);
-        println!("{:?}", t);
         assert_almost_eq(t.x(), 0.0023780939236960497);
         assert_almost_eq(t.y(), 0.8992266861799759);
     }
@@ -255,7 +254,6 @@ mod test {
         let t = nad83_m
             .convert(Point::new(4760096.421921, 3744293.729449))
             .unwrap();
-        println!("{:?}", t);
         assert_almost_eq(t.x(), 1450880.29);
         assert_almost_eq(t.y(), 1141263.01);
     }
@@ -266,10 +264,8 @@ mod test {
         let _ = Proj::new("ugh").unwrap();
     }
     #[test]
-    #[should_panic]
-    // This will panic with an error message containing the proj error string,
-    // because step 1 isn't an inverse conversion, which means it's expecting lon lat input
     fn test_conversion_error() {
+        // because step 1 isn't an inverse conversion, it's expecting lon lat input
         let nad83_m = Proj::new("
             +proj=pipeline
             +step +proj=lcc +lat_1=33.88333333333333
@@ -280,9 +276,12 @@ mod test {
             +lon_0=-116.25 +x_0=2000000 +y_0=500000
             +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
         ").unwrap();
-        // Presidio, San Francisco
-        let _ = nad83_m
+        let err = nad83_m
             .convert(Point::new(4760096.421921, 3744293.729449))
-            .unwrap();
+            .unwrap_err();
+        assert_eq!(
+            "The conversion failed with the following error: latitude or longitude exceeded limits",
+            err.root_cause().to_string()
+        );
     }
 }

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -243,8 +243,8 @@ mod test {
         ).unwrap();
         // OSGB36 (EPSG 27700) -> Geodetic
         let t = osgb36.project(Point::new(548295.39, 182498.46), true).unwrap();
-        assert_almost_eq(t.x(), 0.0023780939236960497);
-        assert_almost_eq(t.y(), 0.8992266861799759);
+        assert_almost_eq(t.x(), 0.0023755864848281206);
+        assert_almost_eq(t.y(), 0.8992274896304518);
     }
     #[test]
     // Carry out a conversion from NAD83 feet (EPSG 2230) to NAD83 metres (EPSG 26946)

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -32,8 +32,8 @@ impl Proj {
     /// Try to instantiate a new `proj.4` instance
     ///
     /// **Note:** for projection operations, `definition` specifies
-    // the **output** projection; input coordinates
-    /// are assumed to be geodetic, unless an inverse projection is intended.
+    /// the **output** projection; input coordinates
+    /// are assumed to be geodetic in radians, unless an inverse projection is intended.
     ///
     /// For conversion operations, `definition` defines input, output, and
     /// any intermediate steps that are required. See the `convert` example for more details.
@@ -76,10 +76,10 @@ impl Proj {
         let rv = unsafe { proj_pj_info(self.c_proj) };
         _string(rv.definition)
     }
-    /// Project geodetic `Point` coordinates into the projection specified by `definition`
+    /// Project geodetic `Point` coordinates (in radians) into the projection specified by `definition`
     ///
     /// **Note:** specifying `inverse` as `true` carries out an inverse projection *to* geodetic coordinates
-    /// from the projection specified by `definition`.
+    /// (in radians) from the projection specified by `definition`.
     pub fn project<T>(&self, point: Point<T>, inverse: bool) -> Point<T>
     where
         T: Float,

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -130,7 +130,16 @@ impl Proj {
     /// extern crate geo;
     /// use geo::Point;
     ///
-    /// let nad_ft_to_m = Proj::new("+proj=pipeline +step +inv +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000 +y_0=500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs").unwrap();
+    /// let nad_ft_to_m = Proj::new("
+    ///     +proj=pipeline
+    ///     +step +inv +proj=lcc +lat_1=33.88333333333333
+    ///     +lat_2=32.78333333333333 +lat_0=32.16666666666666
+    ///     +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80
+    ///     +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs
+    ///     +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666
+    ///     +lon_0=-116.25 +x_0=2000000 +y_0=500000
+    ///     +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
+    /// ").unwrap();
     /// let result = nad_ft_to_m.convert(Point::new(4760096.421921, 3744293.729449)).unwrap();
     /// assert_eq!(result.x(), 1450880.29);
     /// assert_eq!(result.y(), 1141263.01);
@@ -194,8 +203,9 @@ mod test {
     // Carry out a projection from geodetic coordinates
     fn test_projection() {
         let stereo70 = Proj::new(
-            "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs"
-            ).unwrap();
+            "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000
+            +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs",
+        ).unwrap();
         // Geodetic -> Pulkovo 1942(58) / Stereo70 (EPSG 3844)
         let t = stereo70.project(Point::new(0.436332, 0.802851), false);
         assert_almost_eq(t.x(), 500119.70352012233);
@@ -205,7 +215,8 @@ mod test {
     // Carry out an inverse projection to geodetic coordinates
     fn test_inverse_projection() {
         let stereo70 = Proj::new(
-            "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000 +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs"
+            "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 +y_0=500000
+            +ellps=krass +towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 +units=m +no_defs"
             ).unwrap();
         // Pulkovo 1942(58) / Stereo70 (EPSG 3844) -> Geodetic
         let t = stereo70.project(Point::new(500119.70352012233, 500027.77896348457), true);
@@ -215,9 +226,16 @@ mod test {
     #[test]
     // Carry out a conversion from NAD83 feet (EPSG 2230) to NAD83 metres (EPSG 26946)
     fn test_conversion() {
-        let nad83_m = Proj::new(
-            "+proj=pipeline +step +inv +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000 +y_0=500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
-        ).unwrap();
+        let nad83_m = Proj::new("
+            +proj=pipeline
+            +step +inv +proj=lcc +lat_1=33.88333333333333
+            +lat_2=32.78333333333333 +lat_0=32.16666666666666
+            +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80
+            +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs
+            +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666
+            +lon_0=-116.25 +x_0=2000000 +y_0=500000
+            +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
+        ").unwrap();
         // Presidio, San Francisco
         let t = nad83_m
             .convert(Point::new(4760096.421921, 3744293.729449))
@@ -230,8 +248,6 @@ mod test {
     #[should_panic]
     // Test that instantiation fails wth bad input
     fn test_bad_proj_string() {
-        let ugh = Proj::new(
-            "ugh"
-        ).unwrap();
+        let _ = Proj::new("ugh").unwrap();
     }
 }

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -29,7 +29,7 @@ pub struct Proj {
 }
 
 impl Proj {
-    /// Try to instantiate a new `proj.4` instance
+    /// Try to instantiate a new `PROJ.4` instance
     ///
     /// **Note:** for projection operations, `definition` specifies
     /// the **output** projection; input coordinates
@@ -71,7 +71,7 @@ impl Proj {
     //     }
     // }
 
-    /// Get the current definition from `proj.4`
+    /// Get the current definition from `PROJ.4`
     pub fn def(&self) -> String {
         let rv = unsafe { proj_pj_info(self.c_proj) };
         _string(rv.definition)
@@ -117,7 +117,7 @@ impl Proj {
         }
     }
 
-    /// Convert `Point` coordinates using the proj.4 `pipeline` operator
+    /// Convert `Point` coordinates using the PROJ.4 `pipeline` operator
     ///
     /// This method makes use of the [`pipeline`](http://proj4.org/operations/pipeline.html)
     /// functionality available since v5.0.0, which differs significantly from the v4.x series
@@ -267,10 +267,9 @@ mod test {
         assert_almost_eq(t.y(), 1141263.01);
     }
     #[test]
-    #[should_panic]
     // Test that instantiation fails wth bad proj string input
     fn test_init_error() {
-        let _ = Proj::new("ugh").unwrap();
+        assert!(Proj::new("ugh").is_none());
     }
     #[test]
     fn test_conversion_error() {

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -226,4 +226,12 @@ mod test {
         assert_almost_eq(t.x(), 1450880.29);
         assert_almost_eq(t.y(), 1141263.01);
     }
+    #[test]
+    #[should_panic]
+    // Test that instantiation fails wth bad input
+    fn test_bad_proj_string() {
+        let ugh = Proj::new(
+            "ugh"
+        ).unwrap();
+    }
 }

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -103,7 +103,7 @@ impl Proj {
     /// use geo::Point;
     ///
     /// let nad_ft_to_m = Proj::new("+proj=pipeline +step +inv +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666 +lon_0=-116.25 +x_0=2000000 +y_0=500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs").unwrap();
-    /// let result = nad_ft_to_m.convert(Point::new(4760096.421921, 3744293.729449));
+    /// let result = nad_ft_to_m.convert(Point::new(4760096.421921, 3744293.729449)).unwrap();
     /// assert_eq!(result.x(), 1450880.29);
     /// assert_eq!(result.y(), 1141263.01);
     ///

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -7,9 +7,9 @@ use num_traits::Float;
 use std::ffi::CStr;
 use std::str;
 use failure::Error;
-use proj_sys::{pj_strerrno, proj_context_create, proj_create, proj_destroy, proj_pj_info,
-               proj_trans, PJconsts, PJ_COORD, PJ_DIRECTION_PJ_FWD, PJ_DIRECTION_PJ_INV, PJ_LP,
-               PJ_XY};
+use proj_sys::{pj_strerrno, proj_context_create, proj_create, proj_create_crs_to_crs,
+               proj_destroy, proj_pj_info, proj_trans, PJconsts, PJ_AREA, PJ_COORD,
+               PJ_DIRECTION_PJ_FWD, PJ_DIRECTION_PJ_INV, PJ_LP, PJ_XY};
 
 /// Easily get a String from the external library
 fn _string(raw_ptr: *const c_char) -> String {
@@ -52,6 +52,24 @@ impl Proj {
             Some(Proj { c_proj: new_c_proj })
         }
     }
+
+    // FIXME: we can't implement this yet because PJ_AREA isn't implemented
+    // /// Create a transformation object from two known EPSG CRS codes
+    // pub fn new_known_crs(from: &str, to: &str) -> Option<Proj> {
+    //     let from_c = CString::new(from.as_bytes()).unwrap();
+    //     let to_c = CString::new(to.as_bytes()).unwrap();
+    //     let ctx = unsafe { proj_context_create() };
+    //     // not implemented yet, see http://proj4.org/development/reference/datatypes.html#c.PJ_AREA
+    //     let mut area = PJ_AREA { area: 0 };
+    //     let raw_area = &mut area as *mut PJ_AREA;
+    //     let new_c_proj =
+    //         unsafe { proj_create_crs_to_crs(ctx, from_c.as_ptr(), to_c.as_ptr(), raw_area) };
+    //     if new_c_proj.is_null() {
+    //         None
+    //     } else {
+    //         Some(Proj { c_proj: new_c_proj })
+    //     }
+    // }
 
     /// Get the current definition from `proj.4`
     pub fn def(&self) -> String {

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -224,6 +224,19 @@ mod test {
         assert_almost_eq(t.y(), 0.802851);
     }
     #[test]
+    // Carry out an inverse projection to geodetic coordinates
+    fn test_london_inverse() {
+        let osgb36 = Proj::new("
+            +proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy
+            +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 +units=m +no_defs
+            ").unwrap();
+        // OSGB36 (EPSG 27700) -> Geodetic
+        let t = osgb36.project(Point::new(548295.39, 182498.46), true);
+        println!("{:?}", t);
+        assert_almost_eq(t.x(), 0.0023780939236960497);
+        assert_almost_eq(t.y(),  0.8992266861799759);
+    }
+    #[test]
     // Carry out a conversion from NAD83 feet (EPSG 2230) to NAD83 metres (EPSG 26946)
     fn test_conversion() {
         let nad83_m = Proj::new("


### PR DESCRIPTION
With the surprising release (after about 23 years) of proj.4 v5, and my blowing-the-cobwebs-off PR from yesterday (#5), I thought I'd publish a [`proj-sys`](https://crates.io/crates/proj-sys) crate (generated using `bindgen`), and use it as the basis for this.
Currently, the API contains a very breaking change, because proj.4 performs operations differently now: it distinguishes between _projection_ (conversions from geodetic to projected coordinates) and _conversion_ (conversions between projected coordinate systems, usually within the same datum / reference frame). The latter uses a concept proj.4 calls the [`pipeline`](http://proj4.org/operations/pipeline.html), which allows for multi-step operations to achieve almost any kind of conversion, as opposed to the old system, which only allowed the specification of `from` and `to` projections.
This change is mirrored in the rust-proj API: for simple (inverse) projection from/to geodetic coordinates, there's `project`, and for conversions and transformations there's `convert`.
I'm not 100% sold on the API, because it feels a bit less flexible than the old one: you could specify different destination projections, and re-use the `Proj` struct. Using the new API, you have to specify everything up front, but you have a great deal more flexibility in terms of what you can do with it (see the `conversion` example). The conversion function also returns a `Result` now, and errors are implemented using `Failure`.
<s>Anyway, this is currently WIP until I figure out how to detect errors using the new API.</s>