### PR TITLE
Create valid error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "proj"
 description = "Rust bindings for proj.4"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
   "Corey Farwell <coreyf@rwell.org>",
   "Alex Morega <alex@grep.ro>",
+  "Stephan Hügel <urschrei@gmail.com>"
 ]
 repository = "https://github.com/georust/rust-proj"
 keywords = ["proj", "projection", "osgeo", "geo"]

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -275,14 +275,7 @@ mod test {
     fn test_conversion_error() {
         // because step 1 isn't an inverse conversion, it's expecting lon lat input
         let nad83_m = Proj::new("
-            +proj=pipeline
-            +step +proj=lcc +lat_1=33.88333333333333
-            +lat_2=32.78333333333333 +lat_0=32.16666666666666
-            +lon_0=-116.25 +x_0=2000000.0001016 +y_0=500000.0001016001 +ellps=GRS80
-            +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs
-            +step +proj=lcc +lat_1=33.88333333333333 +lat_2=32.78333333333333 +lat_0=32.16666666666666
-            +lon_0=-116.25 +x_0=2000000 +y_0=500000
-            +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
+            +proj=geos +lon_0=0.00 +lat_0=0.00 +a=6378169.00 +b=6356583.80 +h=35785831.0
         ").unwrap();
         let err = nad83_m
             .convert(Point::new(4760096.421921, 3744293.729449))


### PR DESCRIPTION
See discussion at #8 
Error taken from
https://github.com/OSGeo/proj.4/blob/master/test/gie/4D-API_cs2cs-style.gie#L194

5.0.1 now accepts certain nonsensical input, but returns inf, inf
instead of an error. See: https://github.com/OSGeo/proj.4/issues/992#issuecomment-388546006